### PR TITLE
Change VERSION and name to be PEP 440 and PEP 503 compatible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-0.8.2.novapost (2016-01-04)
----------------------------
+0.8.2+peopledoc (2016-08-24)
+----------------------------
 
 - Make django.js compatible for django >= 1.8
 

--- a/djangojs/__init__.py
+++ b/djangojs/__init__.py
@@ -3,7 +3,7 @@
 Django.js provide better integration of javascript into Django.
 '''
 
-__version__ = '0.8.2.novapost'
+__version__ = '0.8.2+peopledoc'
 __description__ = "Django JS Tools"
 
 #: Packaged jQuery version

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if sys.version_info[0:2] < (2, 7):
     install_requires += ['argparse']
 
 setup(
-    name='django.js',
+    name='django-js',
     version=__import__('djangojs').__version__,
     description=__import__('djangojs').__description__,
     long_description=long_description,


### PR DESCRIPTION
Change VERSION from 0.8.2.novapost to 0.8.2+peopledoc for being PEP 440 compliant
Change name from django.js to django-js to be PEP 503 compliant
