### PR TITLE
Load url templatetag without future in templates

### DIFF
--- a/djangojs/templates/djangojs/django_js_init.html
+++ b/djangojs/templates/djangojs/django_js_init.html
@@ -1,5 +1,4 @@
-{% load js %}
-{% load url from future %}
+{% load js url %}
 <script type="text/javascript" src="{% url "django_js_init" %}"></script>
 {% if js.i18n %}
 <script type="text/javascript" src="{% url "js_catalog" %}"></script>

--- a/djangojs/templates/djangojs/test/djangojs-test-runner.html
+++ b/djangojs/templates/djangojs/test/djangojs-test-runner.html
@@ -1,7 +1,6 @@
 {% extends "djangojs/jasmine-runner.html" %}
 
-{% load js %}
-{% load url from future %}
+{% load js url %}
 
 {% block js_content %}
     {% include "djangojs/test/test-data.html" %}


### PR DESCRIPTION
We had this warning:

> RemovedInDjango19Warning: Loading the `url` tag from the `future`
> library is deprecated and will be removed in Django 1.9. Use the
> default `url` tag instead.