### PR TITLE
Do not load url templatetag

### DIFF
--- a/djangojs/templates/djangojs/django_js_init.html
+++ b/djangojs/templates/djangojs/django_js_init.html
@@ -1,4 +1,4 @@
-{% load js url %}
+{% load js %}
 <script type="text/javascript" src="{% url "django_js_init" %}"></script>
 {% if js.i18n %}
 <script type="text/javascript" src="{% url "js_catalog" %}"></script>

--- a/djangojs/templates/djangojs/test/djangojs-test-runner.html
+++ b/djangojs/templates/djangojs/test/djangojs-test-runner.html
@@ -1,6 +1,6 @@
 {% extends "djangojs/jasmine-runner.html" %}
 
-{% load js url %}
+{% load js %}
 
 {% block js_content %}
     {% include "djangojs/test/test-data.html" %}

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, pypy,
-    py26-django-1.4, py27-django-1.4, pypy-django-1.4,
+envlist =
     py26-django-1.5, py27-django-1.5, py32-django-1.5, py33-django-1.5, pypy-django-1.5,
     py26-django-1.7, py27-django-1.7, py32-django-1.7, py33-django-1.7, pypy-django-1.7,
     doc
@@ -17,23 +16,8 @@ deps = django>=1.6
 [django-1.5]
 deps = django>=1.5,<1.6
 
-[django-1.4]
-deps = django>=1.4,<1.5
-
 [django-1.7]
-deps = https://www.djangoproject.com/download/1.7c1/tarball/
-
-[testenv:py26-django-1.4]
-basepython = python2.6
-deps = {[django-1.4]deps}
-
-[testenv:py27-django-1.4]
-basepython = python2.7
-deps = {[django-1.4]deps}
-
-[testenv:pypy-django-1.4]
-basepython = pypy
-deps = {[django-1.4]deps}
+deps = django>=1.7,<1.8
 
 [testenv:py26-django-1.5]
 basepython = python2.6


### PR DESCRIPTION
As the url tag is part of the built-in templatetags
(django.template.defaulttags), there should be nothing to import.
Rendering this template would raise an error like 'url' is not a
registered library. We simply get rid of the `{% load url %}`.

Helped-by: @hsmett